### PR TITLE
微调overview布局，视觉效果上对齐元素网格

### DIFF
--- a/src/views/component/overview/overview.css
+++ b/src/views/component/overview/overview.css
@@ -332,7 +332,7 @@ html {
 table.weapon-table,
 table.character-table {
   border-spacing: 0 !important;
-  width: 450px;
+  width: 460px;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
人物和武器均有改动，仅以武器展示

改动前：
![image](https://user-images.githubusercontent.com/9006264/137585469-cf1ef982-7799-4800-a2e7-a4aaeea8b8f2.png)

改动后：
![image](https://user-images.githubusercontent.com/9006264/137585429-a041f050-3582-470c-a5f5-ac92a35e9f8f.png)

